### PR TITLE
Reduce unnecessary .trans.c boilerplate text

### DIFF
--- a/Transform.cpp
+++ b/Transform.cpp
@@ -1583,6 +1583,7 @@ namespace {
     bool TreatAsCHeader(SourceLocation Loc) {
       if(Loc.isInvalid()) return false;
       SourceManager& SrcManager = SemaRef.Context.getSourceManager();
+      if(SrcManager.getFileID(Loc) == SrcManager.getMainFileID()) return false;
       StringRef Name = llvm::sys::path::filename(SrcManager.getFilename(Loc));
       return UPCSystemHeaders.find(Name) == UPCSystemHeaders.end() &&
 	SrcManager.isInSystemHeader(Loc);


### PR DESCRIPTION
Please consider pulling these changes.
Self-explanatory commit message follows.

-Paul

This commit reduces the boilerplate at the top of each .trans.c file.

Background:

The upcrt_ namespace is reserved for use by the translator, and with the sole
exception of the UPCRT_STARTUP_(P)SHALLOC macros there is no reference by the
runtime or driver to any names in this namespace.

The 3.8 version of the UPCR spec was introduced in 2006.  Therefore it is quite
safe to assume that upc2c is not generating code to be used with a runtime spec
older than that.

The specific changes:

1) The "...forall_control" variable belongs in the upcrt_ namespace.  So, I've
renamed "upcr_forall_control" to "upcrt_forall_control" throughout and remove
the following from the boilerplate:
   #define upcr_forall_control upcrt_forall_control
This define existed only in the Berkeley UPC translator's output for legacy
compatibility reasons.

2) Both "upcrt_gcd()" and "_upcrt_forall_start()" are specific to the
Berkeley translator.  Since upc2c does not use them, they can be removed from
the boilerplate (UPCR will never reference them).

3) Since we can be certain of a runtime spec 3.8 or newer, the conditional
definition of UPCRT_STARTUP_SHALLOC can be made unconditional.

4) The issue of undefined "_S_trans" types has been resolved by properly
conditionalizing some bupc-specific logic in upcr_preinclude/upc_io_bits.h.
Thus upc2c no longer needs to emit the definitions.
