### PR TITLE
Alternative PTS-to-Integer conversion using upc_addrfield()

### DIFF
--- a/Transform.cpp
+++ b/Transform.cpp
@@ -118,6 +118,8 @@ namespace {
     FunctionDecl * UPCR_SHARED_TO_PSHARED;
     FunctionDecl * UPCR_PSHARED_TO_SHARED;
     FunctionDecl * UPCR_SHARED_RESETPHASE;
+    FunctionDecl * UPCR_ADDRFIELD_SHARED;
+    FunctionDecl * UPCR_ADDRFIELD_PSHARED;
     VarDecl * upcrt_forall_control;
     VarDecl * upcr_null_shared;
     VarDecl * upcr_null_pshared;
@@ -315,6 +317,16 @@ namespace {
       {
 	QualType argTypes[] = { upcr_shared_ptr_t };
 	UPCR_SHARED_RESETPHASE = CreateFunction(Context, "upcr_shared_resetphase", upcr_shared_ptr_t, argTypes, sizeof(argTypes)/sizeof(argTypes[0]));
+      }
+      // UPCR_ADDRFIELD_SHARED
+      {
+	QualType argTypes[] = { upcr_shared_ptr_t };
+	UPCR_ADDRFIELD_SHARED = CreateFunction(Context, "upcr_addrfield_shared", Context.getUIntPtrType(), argTypes, 1);
+      }
+      // UPCR_ADDRFIELD_PSHARED
+      {
+	QualType argTypes[] = { upcr_pshared_ptr_t };
+	UPCR_ADDRFIELD_PSHARED = CreateFunction(Context, "upcr_addrfield_pshared", Context.getUIntPtrType(), argTypes, 1);
       }
       // UPCR_BEGIN_FUNCTION
       {
@@ -706,31 +718,13 @@ namespace {
 	}
       } else if(E->getCastKind() == CK_PointerToIntegral &&
 		isPointerToShared(E->getSubExpr()->getType())) {
-	// create temporary
-	// memcpy
-	// load
-	QualType SrcType = TransformType(E->getSubExpr()->getType());
-	QualType DstType = TransformType(E->getType());
-	CharUnits SrcSize = SemaRef.Context.getTypeSizeInChars(E->getSubExpr()->getType());
-	CharUnits DstSize = SemaRef.Context.getTypeSizeInChars(E->getType());
-	if(SrcSize < DstSize) {
-	  VarDecl *Dst = CreateTmpVar(DstType);
-	  Expr * DstVal = CreateSimpleDeclRef(Dst);
-	  Expr * DstAddr = SemaRef.CreateBuiltinUnaryOp(SourceLocation(), UO_AddrOf, DstVal).get();
-	  SemaRef.AddInitializerToDecl(Dst, CreateInteger(SemaRef.Context.IntTy, 0), false, false);
-	  Expr * Target = SemaRef.BuildCStyleCastExpr(SourceLocation(), SemaRef.Context.getTrivialTypeSourceInfo(SemaRef.Context.getPointerType(SrcType)), SourceLocation(), DstAddr).get();
-	  Expr * Deref = SemaRef.CreateBuiltinUnaryOp(SourceLocation(), UO_Deref, Target).get();
-	  Expr * Assign = SemaRef.CreateBuiltinBinOp(SourceLocation(), BO_Assign, Deref, TransformExpr(E->getSubExpr()).get()).get();
-	  return BuildParens(BuildComma(Assign, DstVal).get()).get();
-	} else {
-	  VarDecl *Src = CreateTmpVar(TransformType(E->getSubExpr()->getType()));
-	  Expr * SrcVal = CreateSimpleDeclRef(Src);
-	  Expr * SrcAddr = SemaRef.CreateBuiltinUnaryOp(SourceLocation(), UO_AddrOf, SrcVal).get();
-	  Expr * SetVal = SemaRef.CreateBuiltinBinOp(SourceLocation(), BO_Assign, SrcVal, TransformExpr(E->getSubExpr()).get()).get();
-	  Expr * Result = SemaRef.BuildCStyleCastExpr(SourceLocation(), SemaRef.Context.getTrivialTypeSourceInfo(SemaRef.Context.getPointerType(DstType)), SourceLocation(), SrcAddr).get();
-	  Expr * Deref = SemaRef.CreateBuiltinUnaryOp(SourceLocation(), UO_Deref, Result).get();
-	  return BuildParens(BuildComma(SetVal, Deref).get()).get();
-	}
+	bool Phaseless = isPhaseless(E->getSubExpr()->getType()->getAs<PointerType>()->getPointeeType());
+	FunctionDecl *Accessor = Phaseless? Decls->UPCR_ADDRFIELD_PSHARED : Decls->UPCR_ADDRFIELD_SHARED;
+	std::vector<Expr*> args;
+	args.push_back(TransformExpr(E->getSubExpr()).get());
+	Expr *Result = BuildUPCRCall(Accessor, args).get();
+	TypeSourceInfo *Type = SemaRef.Context.getTrivialTypeSourceInfo(TransformType(E->getType()));
+	return SemaRef.BuildCStyleCastExpr(SourceLocation(), Type, SourceLocation(), Result);
       }
       return ExprError();
     }


### PR DESCRIPTION
This commit implements conversion from pointer-to-shared to
integral types using the UPCR functions for implementing
upc_addrfield().

The previous code, which produced:
   upcr_pshared_ptr_t _bupc_spilld0;
   upcr_shared_ptr_t _bupc_spilld1;
   int p = (_bupc_spilld0 = x , *(int *)&_bupc_spilld0);
   int q = (_bupc_spilld1 = x , *(int *)&_bupc_spilld1);
which may return different portions of the PTS on little-vs-big
endian systems, and may not return the same values for two pointers
to the same object!

The new code produces
   int p = (int)upcr_addrfield_pshared(x);
   int y = (int)upcr_addrfield_shared(y);
